### PR TITLE
Streamlined single page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,276 +1,30 @@
+<!DOCTYPE html>
 <html>
   <head>
-    <title>Pink Trombone Demos</title>
+    <meta charset="UTF-8" />
+    <title>Tosi Ki Rea</title>
+    <style>
+      body {
+        background:#1d3454;
+        color:white;
+        font-family:sans-serif;
+        margin:0;
+      }
+      header {
+        text-align:center;
+        padding:10px;
+      }
+      iframe {
+        width:100%;
+        border:0;
+      }
+    </style>
   </head>
   <body>
-    <h1>Pink Trombone Demos</h1>
-
-    <p>
-      <i
-        >A collection of demos using
-        <a href="http://venuspatrol.nfshost.com/" target="_blank"
-          >Neil Thapen's</a
-        >
-        <a href="https://dood.al/pinktrombone/" target="_blank">Pink Trombone</a
-        >.</i
-      >
-    </p>
-
-    <p>
-      The webpages work by communicating with each other using the
-      <a
-        href="https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel"
-        target="_blank"
-        >BroadcastChannel API</a
-      >, so some pages need other pages open to work, e.g. the
-      <a href="tts/">Text-to-Speech</a>
-      webpage sends messages to the
-      <a href="pink-trombone/">Pink Trombone</a> webpage.
-    </p>
-
-    <p>
-      Source code is available on
-      <a href="https://glitch.com/edit/#!/pink-trombone-demos" target="_blank"
-        >glitch</a
-      >
-      and
-      <a href="https://github.com/zakaton/pink-trombone-demos" target="_blank"
-        >github</a
-      >
-    </p>
-
-    <hr />
-
-    <h3 id="pink-trombone">
-      <a href="/pink-trombone" target="_blank">Pink Trombone</a>
-    </h3>
-    <p>
-      Opens the "Pink Trombone" Speech Synthesizer. Receives messages from the
-      other webpages to control it.
-      <span hidden
-        >Also includes a
-        <a href="/pink-trombone/?dark" target="_blank">dark mode</a> and
-        <a href="/pink-trombone/default.html" target="_blank"
-          >multi-channel mode</a
-        >
-        (you won't need to use these versions)</span
-      >
-    </p>
-
-    <hr />
-
-    <h3 id="debug"><a href="/debug" target="_blank">Debug</a></h3>
-    <p>Used for sending test messages to Pink Trombone</p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-
-    <h3 id="pitch"><a href="/pitch" target="_blank">Pitch</a></h3>
-    <p>Gets the microphone's Pitch and sends it to Pink Trombone.</p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-
-    <!--
-    <h3 id="machine-learning">
-      Machine Learning (<a href="/machine-learning" target="_blank"
-        >Meyda.js MFCC</a
-      >) <span hidden>(<a href="/machine-learning/?essentia" target="_blank"
-        >Essentia.js Mel Spectrogram</a
-      >)</span>
-    </h3>
-    <p>
-      Uses
-      <a href="https://ml5js.org/" target="_blank">ML5.js</a>
-      and <a href="https://meyda.js.org/" target="_blank">Meyda.js's</a>
-      <a
-        href="https://en.wikipedia.org/wiki/Mel-frequency_cepstrum#:~:text=Mel%2Dfrequency%20cepstral%20coefficients%20(MFCCs,%2Da%2Dspectrum%22)."
-        target="_blank"
-        >MFCC</a
-      >
-      <span hidden>(or
-        <a href="https://mtg.github.io/essentia.js/" target="_blank"
-          >Essentia.js's</a
-        >
-        <a href="https://essentiajs-melspectrogram.netlify.app/" target="_blank"
-          >Mel Spectrogram</a
-        >)</span> to create a
-      <a
-        href="https://learn.ml5js.org/#/reference/neural-network"
-        target="_blank"
-        >neural network</a
-      >
-      that maps speech to Pink Trombone parameters.
-    </p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-    -->
-
-    <h3 id="knn">
-      KNN Classifier (<a href="/knn" target="_blank">Meyda.js MFCC</a>)
-      <span hidden
-        >(<a href="/knn/?essentia" target="_blank"
-          >Essentia.js Mel Spectrogram</a
-        >)</span
-      >
-    </h3>
-
-    <p></p>
-    <p>
-      Uses
-      <a href="https://ml5js.org/" target="_blank">ML5.js</a>
-      and <a href="https://meyda.js.org/" target="_blank">Meyda.js's</a>
-      <a
-        href="https://en.wikipedia.org/wiki/Mel-frequency_cepstrum#:~:text=Mel%2Dfrequency%20cepstral%20coefficients%20(MFCCs,%2Da%2Dspectrum%22)."
-        target="_blank"
-        >MFCC</a
-      >
-      <span hidden
-        >(or
-        <a href="https://mtg.github.io/essentia.js/" target="_blank"
-          >Essentia.js's</a
-        >
-        <a href="https://essentiajs-melspectrogram.netlify.app/" target="_blank"
-          >Mel Spectrogram</a
-        >)</span
-      >
-      to create a
-      <a
-        href="https://learn.ml5js.org/#/reference/knn-classifier"
-        target="_blank"
-        >KNN Classifier</a
-      >
-      that maps speech to Pink Trombone parameters.
-    </p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-
-    <h3 id="3d"><a href="/3d" target="_blank">3D Navigation</a></h3>
-
-    <p></p>
-    <p>
-      Moves around an
-      <a href="https://aframe.io/" target="_blank">A-FRAME</a> scene using the
-      <a href="#knn">KNN Classifier</a>, using classes <b><i>forward</i></b
-      >, <b><i>backward</i></b
-      >, <b><i>left</i></b
-      >, <b><i>right</i></b
-      >, <b><i>up</i></b
-      >, and <b><i>down</i></b>
-    </p>
-    <p>
-      <i
-        >requires <a href="#pink-trombone">Pink Trombone</a> and
-        <a href="#knn">KNN Classifier</a></i
-      >
-    </p>
-
-    <hr />
-    <h3 id="reangrid">
-      <a href="/synth/synthesizer.html" target="_blank">Rea Ngana Grid</a>
-    </h3>
-    <p>
-      A kalimba-style grid interface where you can place phonemes on a
-      pitch/time grid to create utterances visually. Snaps to BPM and pitch
-      scale like a vocal sequencer.
-    </p>
-    <p>
-      <i
-        >requires <a href="#pink-trombone">Pink Trombone</a> and
-        <a href="#tts">Text to Speech</a></i
-      >
-    </p>
-
-    <h3 id="tts"><a href="/tts" target="_blank">Text to Speech</a></h3>
-
-    <p></p>
-    <p>
-      Converts text to timed phonemes, and then sends the timed phonemes to the
-      Pink Trombone.
-    </p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-
-    <h3 id="lip-sync">
-      <a href="/lip-sync" target="_blank">Avatar Lip Sync</a>
-    </h3>
-
-    <p></p>
-    <p>
-      Receives timed phonemes from <a href="#tts">Text to Speech</a> and
-      animates a
-      <a href="https://readyplayer.me/" target="_blank">Ready Player Me</a>
-      avatar's mouth.
-    </p>
-    <p>
-      <i
-        >requires <a href="#pink-trombone">Pink Trombone</a> and
-        <a href="#tts">Text to Speech</a></i
-      >
-    </p>
-
-    <hr />
-
-    <h3 id="pronunciation">
-      <a href="/pronunciation" target="_blank">Pronunciation</a>
-    </h3>
-
-    <p></p>
-    <p>
-      Displays the pronunciation of a word, and speaks it aloud as one mouses
-      over the phonemes. One can also speak the phonemes aloud to "read" the
-      word
-    </p>
-    <p>
-      <i
-        >requires <a href="#pink-trombone">Pink Trombone</a> and
-        <a href="#knn">KNN Classifier</a></i
-      >
-    </p>
-
-    <hr />
-
-    <h3 id="rhyming">
-      <a href="/rhyming" target="_blank">Rhyming Dictionary</a>
-    </h3>
-
-    <p></p>
-    <p>Type in a phrase and see all the possible rhyming phrases</p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-
-    <h3 id="edgeImpulse">
-      <a href="/edge-impulse/" target="_blank">Edge Impulse</a>
-    </h3>
-    <!-- iframe goes here -->
-    <p>
-      <a href="" target="_blank">YouTube Video</a>
-    </p>
-    <p>
-      Use Edge Impulse to create a model to control Pink Trombone with your
-      voice
-    </p>
-    <p>
-      <i>requires <a href="#pink-trombone">Pink Trombone</a></i>
-    </p>
-
-    <hr />
-    <p></p>
+    <header>
+      <h1>Tosi Ki Rea</h1>
+    </header>
+    <iframe src="pink-trombone/index.html" style="height:500px;"></iframe>
+    <iframe src="tts/index.html" style="height:650px;"></iframe>
   </body>
 </html>

--- a/pink-trombone/index.html
+++ b/pink-trombone/index.html
@@ -3,6 +3,14 @@
     <title>Pink Trombone</title>
     <script src="/src/utils.js"></script>
     <script src="/pink-trombone/src/pink-trombone.min.js" type="module"></script>
+    <style>
+      body {
+        background: #1d3454;
+        color: white;
+        font-family: sans-serif;
+        margin: 0;
+      }
+    </style>
   </head>
 
   <body>

--- a/tts/index.html
+++ b/tts/index.html
@@ -9,6 +9,12 @@
   </head>
 
   <style>
+    body {
+      background: #1d3454;
+      color: white;
+      font-family: sans-serif;
+      margin: 0;
+    }
     .valid {
       color: green;
       font-weight: bold;
@@ -20,9 +26,6 @@
   </style>
 
   <body>
-    <nav>
-      <a href="../../">home</a>
-    </nav>
     <h1>Tosi Ki Rea</h1>
 
     <textarea id="text" cols="70" placeholder="text"></textarea>


### PR DESCRIPTION
## Summary
- replace index with simple single-page layout using iframes
- style pink-trombone and tts pages to match the original dark colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672bddd6308322a65b6a0b6856c704